### PR TITLE
Simplify and extend Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 # Run test
 script:
-  - nosetests --with-cov --cov sphinxcontrib-pyexec -v -s
+  - nosetests --with-cov --cov pyexec -v -s
 
 notifications:
   slack: 3point:n4uGopqXrpbYFbslpV5z0tyO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,20 @@
 language: python
 python:
   - 2.7
+  - 3.3
   - 3.4
+  - 3.5
 
 sudo: false
 
-env:
-    - TEST_DIR="tests"
-
-# Setup anaconda
-before_install:
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86_64.sh -O miniconda.sh; fi
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/anaconda3/bin:/home/travis/anaconda/bin:/home/travis/miniconda3/bin:/home/travis/miniconda/bin:$PATH
-  - conda update --yes conda
-
-# Install packages
 install:
-  - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy nose sphinx
   - pip install nose-cov python-coveralls
   - pip install -r requirements.txt
 
 # Run test
 script:
-  - nosetests $TEST_DIR
+  - nosetests --with-cov --cov sphinxcontrib-pyexec -v -s
+
+notifications:
+  slack: 3point:n4uGopqXrpbYFbslpV5z0tyO
+  email: false


### PR DESCRIPTION
- Moved away from Anaconda to use built-in Python. This also lets us test on more versions of Python.
- Set up hook for Coveralls (if we want that).
- Switch notifications to Slack

Thoughts?
